### PR TITLE
Modification for migration and bug fixes

### DIFF
--- a/make.inc
+++ b/make.inc
@@ -12,5 +12,6 @@ BVE = $(BUILD)/ve
 BVE_OMP = $(BUILD)/ve_omp
 BVH = $(BUILD)/vh
 BB  = $(BUILD)/bin
-BLIB = $(BUILD)/lib
+BVELIB = $(BUILD)/lib
+BLIB = $(BUILD)/lib64
 BINC = $(BUILD)/include

--- a/src/Makefile
+++ b/src/Makefile
@@ -7,8 +7,9 @@ include ../make.inc
 VHLIB_OBJ := init_hook.o vh_shm.o vh_urpc.o urpc_common.o memory.o
 VELIB_OBJ := init_hook.o ve_urpc.o urpc_common.o memory.o
 
-LIBS := $(addprefix $(BLIB)/,liburpcVH.so liburpcVE.so liburpcVE_omp.so \
-  liburpcVH.a liburpcVE.a liburpcVE_omp.a)
+LIBS := $(addprefix $(BLIB)/,liburpcVH.so liburpcVH.a )
+VELIBS := $(addprefix $(BVELIB)/,liburpcVE.so liburpcVE_omp.so \
+  liburpcVE.a liburpcVE_omp.a)
 INCLUDES := $(addprefix $(BINC)/,urpc.h urpc_debug.h urpc_time.h)
 
 VHLIB_OBJS := $(addprefix $(BVH)/,$(VHLIB_OBJ))
@@ -16,7 +17,7 @@ VELIB_OBJS := $(addprefix $(BVE)/,$(VELIB_OBJ))
 VELIB_OBJS_OMP := $(addprefix $(BVE_OMP)/,$(VELIB_OBJ))
 
 
-ALL: $(LIBS) $(INCLUDES)
+ALL: $(LIBS) $(VELIBS) $(INCLUDES)
 
 
 .PRECIOUS: $(BUILD)/ $(BUILD)%/ $(DEST)/ $(DEST)%/
@@ -40,8 +41,9 @@ ALL: $(LIBS) $(INCLUDES)
 %/init_hook_ve.o: init_hook.c urpc_common.h urpc.h
 
 
-install: $(LIBS) $(INCLUDES) | $(PREF)$(DEST)/lib/ $(PREF)$(DEST)/include/
-	/usr/bin/install -t $(PREF)$(DEST)/lib $(LIBS)
+install: $(LIBS) $(VELIBS) $(INCLUDES) | $(PREF)$(DEST)/lib64/ $(PREF)$(DEST)/lib/ $(PREF)$(DEST)/include/
+	/usr/bin/install -t $(PREF)$(DEST)/lib64 $(LIBS)
+	/usr/bin/install -t $(PREF)$(DEST)/lib $(VELIBS)
 	/usr/bin/install -t $(PREF)$(DEST)/include $(INCLUDES)
 
 
@@ -54,21 +56,21 @@ $(BLIB)/liburpcVH.so: $(VHLIB_OBJS) | $$(@D)/
 	$(GCC) $(GCCFLAGS) -fpic -shared -o $@ $^
 #	$(GCC) $(GCCFLAGS) -fpic -Wl,--version-script=liburpc_vh.map -shared -o $@ $^
 
-$(BLIB)/liburpcVE.so: $(VELIB_OBJS) | $$(@D)/
+$(BVELIB)/liburpcVE.so: $(VELIB_OBJS) | $$(@D)/
 	$(NCC) -v -Wl,-zdefs $(NCCFLAGS) -fpic -shared -o $@ $^ -lveio -lveftrace
 #	$(NCC) -v -Wl,-zdefs -Wl,--version-script=liburpc_ve.map $(NCCFLAGS) -fpic -shared -o $@ $^ -lveio
 
-$(BLIB)/liburpcVE_omp.so: $(VELIB_OBJS_OMP) | $$(@D)/
+$(BVELIB)/liburpcVE_omp.so: $(VELIB_OBJS_OMP) | $$(@D)/
 	$(NCC) -Wl,-zdefs $(NCCFLAGS) -fpic -shared -fopenmp -o $@ $^ -lveio -lveftrace
 #	$(NCC) -Wl,-zdefs -Wl,--version-script=liburpc_ve.map $(NCCFLAGS) -fpic -shared -fopenmp -o $@ $< -lveio
 
 $(BLIB)/liburpcVH.a: $(VHLIB_OBJS) | $$(@D)/
 	$(AR) rv $@ $^
 
-$(BLIB)/liburpcVE.a: $(VELIB_OBJS) | $$(@D)/
+$(BVELIB)/liburpcVE.a: $(VELIB_OBJS) | $$(@D)/
 	$(NAR) rv $@ $^
 
-$(BLIB)/liburpcVE_omp.a: $(VELIB_OBJS_OMP) | $$(@D)/
+$(BVELIB)/liburpcVE_omp.a: $(VELIB_OBJS_OMP) | $$(@D)/
 	$(NAR) rv $@ $^
 
 $(BVH)/%.o: %.c | $$(@D)/
@@ -82,5 +84,5 @@ $(BVE)/%.o: %.c | $$(@D)/
 
 
 clean:
-	rm -f $(VHLIB_OBJS) $(VELIB_OBJS) $(VELIB_OBJS_OMP) $(LIBS)
+	rm -f $(VHLIB_OBJS) $(VELIB_OBJS) $(VELIB_OBJS_OMP) $(LIBS) $(VELIBS)
 

--- a/src/urpc.h
+++ b/src/urpc.h
@@ -8,7 +8,7 @@
 #include <string.h>
 #include <pthread.h>
 
-#define MAX_VE_CORES   8
+#define MAX_VE_CORES   10
 /* maximum number of peer currently limited to 80 = 8 VEs * 10 cores */
 #define URPC_MAX_PEERS (8 * MAX_VE_CORES)
 /* the length of the mailbox MUST be a power of 2! */

--- a/src/urpc.h
+++ b/src/urpc.h
@@ -13,7 +13,7 @@
 #define URPC_MAX_PEERS (8 * MAX_VE_CORES)
 /* the length of the mailbox MUST be a power of 2! */
 #define URPC_LEN_MB    256
-#define URPC_BUFF_LEN (64 * 1024 * 1024)
+#define URPC_BUFF_LEN (32 * 1024 * 1024)
 #define URPC_CMD_BITS (8)
 
 #define URPC_MAX_HANDLERS ((1 << URPC_CMD_BITS) - 1)

--- a/src/vh_shm.c
+++ b/src/vh_shm.c
@@ -80,7 +80,7 @@ int vh_shm_wait_peers(int segid)
 			break;
                 if (timediff_us(ts) > 50000000) {
 			rc = -1;
-			perror("vh_shm_wait_peers] Timeout while waiting for peer.");
+			perror("[vh_shm_wait_peers] Timeout while waiting for peer.");
 			break;
 		}
 	}

--- a/src/vh_urpc.c
+++ b/src/vh_urpc.c
@@ -75,7 +75,7 @@ urpc_peer_t *vh_urpc_peer_create(void)
 	 * Allocate shared memory segment
 	 */
 	up->shm_segid = _vh_shm_init(up->shm_key, up->shm_size, &up->shm_addr);
-	if (up->shm_segid == -1) {
+	if (up->shm_segid < 0) {
 		rc = _vh_shm_fini(up->shm_segid, up->shm_addr);
 		errno = -ENOMEM;
 		return NULL;

--- a/src/vh_urpc.c
+++ b/src/vh_urpc.c
@@ -7,7 +7,7 @@
 #include <stdlib.h>
 #include <sys/time.h>
 #include <time.h>
-
+#include <sys/prctl.h>
 #include <sys/types.h>
 #include <sys/ipc.h>
 #include <sys/shm.h>
@@ -180,11 +180,17 @@ int vh_urpc_child_create(urpc_peer_t *up, char *binary,
 		}
 	}
 #endif
-
+	pid_t p_pid = getpid();
 	pid_t c_pid = fork();
 	if (c_pid == 0) {
 		// this is the child
-
+		err = prctl(PR_SET_PDEATHSIG, SIGTERM);
+		if (err == -1) { 
+			perror("ERROR: prctl");
+			_exit(errno);
+		 }
+		if (getppid() != p_pid)
+			exit(1);
 		// set env vars
 		char tmp[16];
 		sprintf(tmp, "%d", up->shm_segid);

--- a/src/vh_urpc.c
+++ b/src/vh_urpc.c
@@ -230,7 +230,7 @@ int vh_urpc_child_destroy(urpc_peer_t *up)
 		printf("Sending SIGKILL to child");
 		rc = kill(up->child_pid, SIGKILL);
 		waitpid(up->child_pid, &status, 0);
-		dprintf("waitpid(%d) returned status=%d\n", status);
+		dprintf("waitpid(%d) returned status=%d\n", up->child_pid, status);
 		up->child_pid = -1;
 	}
 	return rc;

--- a/src/vh_urpc.c
+++ b/src/vh_urpc.c
@@ -209,7 +209,7 @@ int vh_urpc_child_create(urpc_peer_t *up, char *binary,
 			_exit(errno);
 		}
 		/* Not Reached */
-	}  else if (c_pid > 0) {
+	} else if (c_pid > 0) {
 		// this is the parent
 		free(args);
 		up->child_pid = c_pid;

--- a/test/Makefile
+++ b/test/Makefile
@@ -5,7 +5,7 @@ include ../make.inc
 
 NCCFLAGS := $(NCCFLAGS) -I../src
 GCCFLAGS := $(GCCFLAGS) -I../src
-LDFLAGS = -Wl,-rpath,$(abspath $(DEST)/lib) -Wl,-rpath,$(abspath $(BLIB)) -Wl,-rpath,.
+LDFLAGS = -Wl,-rpath,$(abspath $(DEST)/lib64) -Wl,-rpath,$(abspath $(BLIB)) -Wl,-rpath,$(abspath $(BVELIB)) -Wl,-rpath,.
 
 TESTS = $(BB)/ping_vh $(BB)/pong_ve
 
@@ -36,10 +36,10 @@ install: $(TESTS) | $(PREF)$(DEST)/tests/
 .SECONDEXPANSION:
 
 $(BB)/ping_vh: $(BVH)/ping_vh.o $(BVH)/pingpong.o | $$(@D)/
-	$(GCC) $(GCCFLAGS) $(LDFLAGS) -o $@ $^ -L$(BLIB) -lurpcVH
+	$(GCC) $(GCCFLAGS) $(LDFLAGS) -o $@ $^ -L$(BLIB) -L$(BVELIB) -lurpcVH
 
 $(BB)/pong_ve: $(BVE)/pong_ve.o $(BVE)/pingpong.o | $$(@D)/
-	$(NCC) $(NCCFLAGS) $(LDFLAGS) -o $@ $^ -L$(BLIB) -lurpcVE -lveio -lpthread
+	$(NCC) $(NCCFLAGS) $(LDFLAGS) -o $@ $^ -L$(BLIB) -L$(BVELIB) -lurpcVE -lveio -lpthread -lveftrace
 
 
 $(BVH)/%.o: %.c pingpong.h | $$(@D)/


### PR DESCRIPTION
We changed installation path to migrate from VEO to AVEO easily.

We changed the required huge pages to 128MB to 64MB. The installation guide requests system administrators to allocate 64MB huge pages per VE cores for accelerated I/O. We can use them for AVEO (ve-urpc).

We fixed issues found by reviewing and testing.