### PR TITLE
Set VE_PDMA_IO=1 to disable accelerated I/O 

### DIFF
--- a/src/vh_urpc.c
+++ b/src/vh_urpc.c
@@ -219,6 +219,9 @@ int vh_urpc_child_create(urpc_peer_t *up, char *binary,
 			setenv("URPC_VE_CORE", tmp, 1);
 		}
 
+		// Disable accelerated I/O because it uses huge pages
+		setenv("VE_PDMA_IO", "1", 1);
+
 		err = execve(argv[0], argv, environ);
 		if (err) {
 			perror("ERROR: execve");


### PR DESCRIPTION
Set VE_PDMA_IO=1 to disable accelerated I/O  when vh_urpc_child_create() execute aveorun.

In installation guide, we allocate 32 huge pages per VE core.
ve-urpc use 32 huge pages per peer.
Accelerated I/O also uses 32 huge pages per process.
So, we should disable accelerated I/O.